### PR TITLE
feat: add env var to configure webroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This buildpack complements the
 [`buildpack-static-confgen`](https://github.com/ninech/buildpack-static-confgen)
 buildpack, see the `README.md` on why this can't be in a single buildpack.
-This simply requires nginx if an `index.html` can be found in the workspace.
-The build phase is a noop.
+This simply requires nginx if an `index.html` can be found in the workspace or
+if the env var `BP_STATIC_WEBROOT` is configured. The build phase is a noop.
 
 To test the build locally, checkout this repository and then build it with:
 

--- a/detect.go
+++ b/detect.go
@@ -10,7 +10,10 @@ import (
 	"github.com/paketo-buildpacks/packit/v2/scribe"
 )
 
-const indexFile = "index.html"
+const (
+	indexFile  = "index.html"
+	webRootEnv = "BP_STATIC_WEBROOT"
+)
 
 type BuildPlanMetadata struct {
 	Version       string `toml:"version,omitempty"`
@@ -40,6 +43,11 @@ func Detect(logger scribe.Emitter) packit.DetectFunc {
 }
 
 func WebRoot(workingDir string) (string, error) {
+	// the webroot can be set using an env var
+	if v, ok := os.LookupEnv(webRootEnv); ok {
+		return v, nil
+	}
+
 	paths := []string{"./", "./public"}
 	publicDir := ""
 	for _, path := range paths {

--- a/detect_test.go
+++ b/detect_test.go
@@ -97,4 +97,20 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).To(MatchError(packit.Fail.WithMessage("no index.html found")))
 		})
 	})
+
+	context("when webroot is set via env", func() {
+		it.Before(func() {
+			t.Setenv(webRootEnv, "custom")
+		})
+
+		it("requires nginx", func() {
+			result, err := Detect(scribe.NewEmitter(buffer))(packit.DetectContext{
+				WorkingDir: workingDir,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Plan.Requires).To(ContainElement(packit.BuildPlanRequirement{
+				Name: nginx.NGINX, Metadata: BuildPlanMetadata{Launch: true},
+			}))
+		})
+	})
 }

--- a/init_test.go
+++ b/init_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestUnitBuildpackStatic(t *testing.T) {
-	suite := spec.New("buildpack-static-require", spec.Report(report.Terminal{}), spec.Parallel())
+	suite := spec.New("buildpack-static-require", spec.Report(report.Terminal{}))
 	suite("Detect", testDetect)
 	suite.Run(t)
 }


### PR DESCRIPTION
this adds a new env var that overrides the webroot and will also allow it to pass detection even if there is no `public.html` in any of the expected places.