### PR TITLE
feat: export WebRootEnv

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	indexFile  = "index.html"
-	webRootEnv = "BP_STATIC_WEBROOT"
+	WebRootEnv = "BP_STATIC_WEBROOT"
 )
 
 type BuildPlanMetadata struct {
@@ -44,7 +44,7 @@ func Detect(logger scribe.Emitter) packit.DetectFunc {
 
 func WebRoot(workingDir string) (string, error) {
 	// the webroot can be set using an env var
-	if v, ok := os.LookupEnv(webRootEnv); ok {
+	if v, ok := os.LookupEnv(WebRootEnv); ok {
 		return v, nil
 	}
 

--- a/detect_test.go
+++ b/detect_test.go
@@ -100,7 +100,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 	context("when webroot is set via env", func() {
 		it.Before(func() {
-			t.Setenv(webRootEnv, "custom")
+			t.Setenv(WebRootEnv, "custom")
 		})
 
 		it("requires nginx", func() {


### PR DESCRIPTION
We need to access the webroot env variable in our confgen buildpack, not just the `WebRoot` function.